### PR TITLE
skip all tests at start

### DIFF
--- a/test/atoms_test.exs
+++ b/test/atoms_test.exs
@@ -2,14 +2,17 @@ defmodule AtomsTest do
   use ExUnit.Case
   doctest ElixirDataStructures
 
+  @tag :skip
   test "converts atom to string" do
     assert Atoms.atom_to_string(:my_atom) == "my_atom"
   end
 
+  @tag :skip
   test "converts string to atom" do
     assert Atoms.string_to_atom("my_atom") == :my_atom
   end
 
+  @tag :skip
   test "don't create an untrusted atom - only one that has already been defined" do
     catch_error Atoms.string_to_atom("this_should_not_exist")
   end

--- a/test/conversions_test.exs
+++ b/test/conversions_test.exs
@@ -2,6 +2,7 @@ defmodule ConversionsTest do
   use ExUnit.Case
   doctest ElixirDataStructures
 
+  @tag :skip
   test "converts a list of tuples to a map" do
     list = [{:one, "foo"}, {:two, "bar"}]
     expected = %{one: "foo", two: "bar"}
@@ -11,24 +12,28 @@ defmodule ConversionsTest do
   # When the above works, this one will too.
   # This is just to show that a keyword list is the same thing
   # as a list of doubles (tuple with 2 elements)
+  @tag :skip
   test "converts a keyword list to a map" do
     keyword_list = [one: "foo", two: "bar"]
     expected = %{one: "foo", two: "bar"}
     assert Conversions.list_to_map(keyword_list) == expected
   end
 
+  @tag :skip
   test "converts a keyword list to a map, but only when the value starts with 'b'" do
     keyword_list = [one: "foo", two: "bar", three: "baz"]
     expected = %{two: "bar", three: "baz"}
     assert Conversions.list_to_map_with_b_values(keyword_list) == expected
   end
 
+  @tag :skip
   test "convert a map to a list of tuples" do
     map = %{one: "foo", two: "bar"}
     expected = [{:one, "foo"}, {:two, "bar"}]
     assert Conversions.map_to_list(map) == expected
   end
 
+  @tag :skip
   test "converts a list of tuples to map, but removes any where the map would have a duplicate value" do
     # {:one, "foo"} and {:three, "foo"} both contain "foo", so don't include {:three, "foo"} in the map.
     list = [{:one, "foo"}, {:two, "bar"}, {:three, "foo"}, {:four, "baz"}]
@@ -36,12 +41,10 @@ defmodule ConversionsTest do
     assert Conversions.list_to_map_with_unique_values(list) == expected
   end
 
+  @tag :skip
   test "converts a map to a list, but only if the value in the map is an even number" do
     map = %{foo: 1917, bar: 2196, baz: 4081, big: 2571442}
     expected = [{:bar, 2196}, {:big, 2571442}]
     assert Conversions.map_to_list_with_even_values(map) == expected
   end
-
-
-
 end

--- a/test/structs_test.exs
+++ b/test/structs_test.exs
@@ -20,11 +20,13 @@ defmodule StructsTest do
     {:ok, concerts: concerts}
   end
 
+  @tag :skip
   test "list of all bands playing", %{concerts: concerts} do
     expected = ["Depeche Mode", "Rolling Stones", "Nickleback"]
     assert Structs.concert_names(concerts) == expected
   end
 
+  @tag :skip
   test "list of bands playing before June 15, 2018", %{concerts: concerts} do
     expected = ["Depeche Mode", "Rolling Stones"]
     actual = "2018-06-15T00:00:00Z"


### PR DESCRIPTION
This will set all tests to be skipped at start so you can focus on one at a time.